### PR TITLE
Add some sparse file support to copytree.  This only copies holes

### DIFF
--- a/bsd/_bsd.pyx
+++ b/bsd/_bsd.pyx
@@ -140,7 +140,13 @@ class ProcessLookupPredicate(enum.IntEnum):
     GID = defs.KERN_PROC_GID
     INC_THREAD = defs.KERN_PROC_INC_THREAD
 
-
+class SeekConstants(enum.IntEnum):
+    SEEK_SET = defs.SEEK_SET
+    SEEK_CUR = defs.SEEK_CUR
+    SEEK_END = defs.SEEK_END
+    SEEK_HOLE = defs.SEEK_HOLE
+    SEEK_DATA = defs.SEEK_DATA
+    
 cdef class MountPoint(object):
     cdef defs.statfs* statfs
     cdef bint free

--- a/defs.pxd
+++ b/defs.pxd
@@ -34,6 +34,13 @@ cdef extern from "limits.h":
 
 
 cdef extern from "unistd.h" nogil:
+    enum:
+        SEEK_SET
+        SEEK_CUR
+        SEEK_END
+        SEEK_HOLE
+        SEEK_DATA
+
     void closefrom(int lowfd)
     void setproctitle(const char *fmt, ...)
 


### PR DESCRIPTION
that already exist, it doesn't attempt to find holes by looking for
sequences of NULs.

Ticket: #20371